### PR TITLE
Live Collab fixed share link and no edit note auto save (cancel works)

### DIFF
--- a/packages/express-backend/models/note-services.js
+++ b/packages/express-backend/models/note-services.js
@@ -51,6 +51,16 @@ async function updateNote(id, userId, updatedFields) {
 
 async function enableShare(id, userId) {
   try {
+    const existingNote = await Note.findOne({ _id: id, userId });
+
+    if (!existingNote) {
+      return undefined;
+    }
+
+    if (existingNote.isShared && existingNote.shareId) {
+      return existingNote;
+    }
+
     const shareId = crypto.randomBytes(8).toString("hex");
 
     return await Note.findOneAndUpdate(
@@ -59,7 +69,7 @@ async function enableShare(id, userId) {
         isShared: true,
         shareId,
       },
-      { new: true },
+      { returnDocument: "after" },
     );
   } catch (error) {
     console.log(error);

--- a/packages/react-frontend/src/components/NotesScreen.jsx
+++ b/packages/react-frontend/src/components/NotesScreen.jsx
@@ -379,17 +379,8 @@ function NotesScreen({
                     type="text"
                     value={editTitle}
                     onChange={(e) => {
-                      const newTitle = e.target.value;
-
-                      setEditTitle(newTitle);
+                      setEditTitle(e.target.value);
                       setHasUnsavedChanges(true);
-
-                      if (activeShareId) {
-                        onEmitSharedNoteChange?.(activeShareId, {
-                          title: newTitle,
-                          body: editBody,
-                        });
-                      }
                     }}
                     autoFocus
                     className="w-full border-none bg-transparent text-2xl font-bold text-foreground outline-none placeholder:text-muted-foreground"
@@ -407,17 +398,8 @@ function NotesScreen({
                     <textarea
                       value={editBody}
                       onChange={(e) => {
-                        const newBody = e.target.value;
-
-                        setEditBody(newBody);
+                        setEditBody(e.target.value);
                         setHasUnsavedChanges(true);
-
-                        if (activeShareId) {
-                          onEmitSharedNoteChange?.(activeShareId, {
-                            title: editTitle,
-                            body: newBody,
-                          });
-                        }
                       }}
                       placeholder="Start typing your note..."
                       className="flex-1 w-full resize-none border-none bg-transparent text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground"


### PR DESCRIPTION
When sharing a live collab link, each time a user shares it creates a new session and session link, now the same link is used for the same session/note without creating extra/un needed share/collab links. 
Also when editing notes, they no longer auto save, meaning that now changes must be saved with 'save' button and 'cancel' now should work to properly cancel changes